### PR TITLE
Fix bug with recurring payments

### DIFF
--- a/extension-4.2/com.drastikbydesign.stripe/CRM/Core/Payment/Stripe.php
+++ b/extension-4.2/com.drastikbydesign.stripe/CRM/Core/Payment/Stripe.php
@@ -470,7 +470,7 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     $query_params = array(
       1 => array($stripe_customer->id, 'String'),
       2 => array($invoice_id, 'String'),
-      3 => array($end_time, 'Timestamp'),
+      3 => array($end_time, 'String'),
     );
 
     CRM_Core_DAO::executeQuery("INSERT INTO civicrm_stripe_subscriptions


### PR DESCRIPTION
The payment fails everytime you try to submit a recurring payment because CiviCRM does not recognize $end_time as a Timestamp. If you cange timestamp to string, everything works fine.
