### PR TITLE
4.2 1.6

### DIFF
--- a/com.drastikbydesign.stripe/CRM/Stripe/Page/Webhook.php
+++ b/com.drastikbydesign.stripe/CRM/Stripe/Page/Webhook.php
@@ -139,7 +139,7 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
           %11, %12, '1', %13)",
           $query_params);
 
-          if ($time_compare > $end_time) {
+          if (!empty($end_time) && $time_compare > $end_time) {
             $end_date = date("Y-m-d H:i:s", $end_time);
             // Final payment.  Recurring contribution complete.
             $stripe_customer->cancelSubscription();


### PR DESCRIPTION
These two commits fix a couple of issues with the extension.

The first fixes an error that gets thrown if the number of installments for a recurring contribution is blank, which happens when a user wishes to continue the recurring contribution indefinitely.

The second deals with how to handle multiple recurring contributions for the same contact.  Currently, if this happens, if just the amount is changed, Stripe will not charge the new amount until the next subscription invoice is due.  In CiviCRM, it's expected that the new recurring contribution will be charged immediately. Since Stripe does not support multiple subscriptions per contact/customer, the easiest way to handle this is to cancel the existing active recurring contribution before creating a new one.  That way, the new contribution will always be immediately charged.
