### PR TITLE
Don't use livemode parameter.

### DIFF
--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -453,7 +453,6 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
         'name' => "CiviCRM every {$frequency_interval} {$frequency}s {$formatted_amount}",
         'currency' => strtolower($params['currencyID']),
         'id' => $plan_id,
-        'livemode' => (boolean) $transaction_mode,
         'interval_count' => $frequency_interval,
       );
 


### PR DESCRIPTION
Usually when we setup staging and test sites, we set the Stripe payment
processor keys to use the test keys for both test payments and "live"
payments. This lets us test things more realisticly. Unfortunately, because
we are doing a "live" test, but using the Stripe test keys, the Stripe API
fails with "Received unknown parameter: livemode".

I think the CiviCRM Stripe payment processor should behave like all the other
payment processors and work as expected if you use the test API keys as the
"live" keys.
