### PR TITLE
Add hook path for Wordpress to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The Webhook.php file is registered to the path of civicrm/stripe/webhook
 You will have to make a Webhook rule in your Stripe.com account and enter this path for recurring charges to end!  
 For Drupal:  https://example.com/civicrm/stripe/webhook  
 For Joomla:  https://example.com/index.php/component/civicrm/?task=civicrm/stripe/webhook  
+For Wordpress:  https://example.com/?page=CiviCRM&q=civicrm/stripe/webhook  
 
 INSTALLATION
 ------------


### PR DESCRIPTION
I found this after a bit of trial and error, it has worked well in testing though. 
