### PR TITLE
Clear onclick attribute of submit button

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -36,6 +36,10 @@
     $.getScript('https://js.stripe.com/v1/', function() {
       Stripe.setPublishableKey(CRM.stripe.pub_key);
     });
+
+    // Remove click listeners from submit button, they cause problems
+    $('.crm-form-submit').attr('onclick', '');
+
     /*
      * Identify the payment form.
      * Don't reference by form#id since it changes between payment pages


### PR DESCRIPTION
In testing this extension, I was having issues of the form submitting before the Stripe token could even be requested. After battling with everything I could think of, I noticed that something was adding JS to the `onclick` attribute of the submit button.

Evidently `onclick` code gets executed regardless of anything declared in `$.submit` (in Chrome, at least) I can't imagine a scenario where this wouldn't jeopardize the communication with Stripe so it seems to make sense that any `onclick` events be wiped.

I'm not sure if this is a responsible fix or not but I thought I'd put it out there for discussion regardless. 

FWIW, I'm testing in WordPress 4.0 with Civi 4.5 stable :wink: 
