### PR TITLE
Customize webhook alert on enable to use UF relative path

### DIFF
--- a/stripe.php
+++ b/stripe.php
@@ -69,9 +69,20 @@ function stripe_civicrm_uninstall() {
  * Implementation of hook_civicrm_enable().
  */
 function stripe_civicrm_enable() {
+  $UF_webhook_paths = array(
+    "Drupal"    => "/civicrm/stripe/webhook",
+    "Drupal6"   => "/civicrm/stripe/webhook",
+    "Joomla"    => "/index.php/component/civicrm/?task=civicrm/stripe/webhook",
+    "WordPress" => "/?page=CiviCRM&q=civicrm/stripe/webhook"
+  );
+  // Use Drupal path as default if the UF isn't in the map above
+  $webookhook_path = (array_key_exists(CIVICRM_UF, $UF_webhook_paths)) ?
+    CIVICRM_UF_BASEURL . $UF_webhook_paths[CIVICRM_UF] :
+    CIVICRM_UF_BASEURL . "civicrm/stripe/webhook";
+
   CRM_Core_Session::setStatus("Stripe Payment Processor Message:
     <br />Don't forget to set up Webhooks in Stripe so that recurring contributions are ended!
-    <br />Webhook path to enter in Stripe: <strong>yoursite.com/civicrm/stripe/webhook</strong>
+    <br />Webhook path to enter in Stripe:<br/><em>$webookhook_path</em>
     <br />");
 
   return _stripe_civix_civicrm_enable();


### PR DESCRIPTION
This is a small enhancement but seems like a no-brainer. Rather than displaying the Drupal webhook path, why not use the constants established by Civi to customize the webhook alert so it's relative to not only the CMS but also the site's url? The result (in WordPress) looks like this:

![webhook-alert](https://cloud.githubusercontent.com/assets/1479206/4490846/cbb2bc36-4a31-11e4-90e5-74733bca6261.png)

The default if the UF isn't found would be to still use `CIVICRM_UF_BASEURL` but just with the Drupal path. What I don't know is if we can rely on the constants always being available. Is there any instance where this wouldn't work?

Further, I think it would be prudent to list the webhook path elsewhere. It would seem as though the settings page for the payment processor would be a good location. What is the appropriate way to go about this? Include a template override in the plugin? I can revise this PR accordingly.
