### PR TITLE
Revised JS logic

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -43,18 +43,6 @@
       Stripe.setPublishableKey($('#stripe-pub-key').val());
     });
 
-    /*
-     * Identify the payment form.
-     * Don't reference by form#id since it changes between payment pages
-     * (Contribution / Event / etc).
-     */
-    //Patch - remove direct child selector and account for dialog forms
-    $('#billing-payment-block').closest('form').addClass('stripe-payment-form');
-    $('#crm-container form').addClass('stripe-payment-form');
-    if ($('#crm-ajax-dialog-1 form').length) {
-      $('#crm-ajax-dialog-1 form').addClass('stripe-payment-form');
-    }
-
     // Intercept form submission.
     $("form.stripe-payment-form").submit(function (event) {
       var $form = $(this);

--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -8,7 +8,6 @@
 
   // Response from Stripe.createToken.
   function stripeResponseHandler(status, response) {
-    var submitButton = $("form.stripe-payment-form input[type='submit']:last");
     if (response.error) {
       $('html, body').animate({scrollTop: 0}, 300);
       // Show the errors on the form.

--- a/stripe.php
+++ b/stripe.php
@@ -108,18 +108,18 @@ function stripe_civicrm_buildForm($formName, &$form) {
     && $form->_paymentProcessor['payment_processor_type'] == 'Stripe'
   ) {
     if (!stristr($formName, '_Confirm') && !stristr($formName, '_ThankYou')) {
-      //if (empty($_GET['type'])) {
       if (!isset($form->_elementIndex['stripe_token'])) {
+        $form->_attributes['class'] .= " stripe-payment-form";
         $form->addElement('hidden', 'stripe_token', NULL, array('id' => 'stripe-token'));
         stripe_add_stripe_js($form);
       }
-      //}
     }
   }
 
   // For the 'Record Contribution' backend page.
   if (($formName == 'CRM_Contribute_Form_Contribution' || $formName == 'CRM_Event_Form_Participant' || $formName == 'CRM_Member_Form_Membership' && !empty($form->_processors)) || stristr($formName, '_Main')) {
     if (!isset($form->_elementIndex['stripe_token'])) {
+      $form->_attributes['class'] .= " stripe-payment-form";
       $form->addElement('hidden', 'stripe_token', NULL, array('id' => 'stripe-token'));
       stripe_add_stripe_js($form);
     }


### PR DESCRIPTION
Lets take time to make sure this change works for all use cases.

This PR addresses several things:
1. #60 - Form was not submitting due to non-specific selector
2. Assign `stripe-payment-form` class when building form in `stripe.php` rather than trying to target on document ready
3.  More caching of jQuery selectors for readability and performance
4.  Clear `onbeforeunload` which was triggering 'Are you sure you want to leave this page' dialog when form submits
5.  Remove `onclick` from submit button -- this was also proposed in #54.  
   By default, Civi adds the following to the submit button: `onclick="return submitOnce(this,'Main','Processing');"`  
   This was cause the form to submit before the `$.submit()` function could suppress it. Thus the stripeToken was created and the form would submit to Civi. This PR clears this attribute but recreates its functionality by disabling the button and changing its text where appropriate.

Thoughts?
