### PR TITLE
Can't update the CRM DOM object in WP frontend

### DIFF
--- a/stripe.php
+++ b/stripe.php
@@ -175,6 +175,14 @@ function stripe_add_stripe_js($form) {
       'pub_key' => $stripe_pub_key,
     )
   ));
+
+  // workaround b/c of CRM-13634
+
+  $config = CRM_Core_Config::singleton();
+
+  if ($config->userFramework == 'WordPress' && get_class($form) != 'CRM_Contribute_Form_Contribution') {
+    CRM_Core_Resources::singleton()->addScript('CRM.stripe = {"pub_key":"'.$stripe_pub_key.'"};');
+  }
 }
 
 /**


### PR DESCRIPTION
WordPress won't allow page content to update the header (https://issues.civicrm.org/jira/browse/CRM-13634) so the pub_key doesn't get saved under CRM.stripe.pub_key.  This adds it via some inline javascript.

Without this, the x-1.8 versions of civicrm_stripe will not work for WordPress.
