### PR TITLE
Prevent sensitive fields from hitting server

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -6,6 +6,12 @@
 
   var $form, $submit, buttonText;
 
+  $form = $('form.stripe-payment-form');
+
+  // Removing name attribute prevents data from being sent to server
+  $form.find('[name="credit_card_number"]').removeAttr('name');
+  $form.find('[name="cvv2"]').removeAttr('name');
+
   // Response from Stripe.createToken.
   function stripeResponseHandler(status, response) {
     if (response.error) {
@@ -41,7 +47,6 @@
       Stripe.setPublishableKey($('#stripe-pub-key').val());
     });
 
-    $form   = $('form.stripe-payment-form');
     $submit = $form.find('[type="submit"]');
 
     $submit.removeAttr('onclick');

--- a/stripe.php
+++ b/stripe.php
@@ -167,6 +167,30 @@ function stripe_civicrm_buildForm($formName, &$form) {
 }
 
 /**
+ * Implementation of hook_civicrm_validateForm().
+ *
+ * Prevent serverside validation of CC/CVV2 so that both fields may be removed from the POST body without errors.
+ *
+ * @param $formName
+ * @param $fields
+ * @param $files
+ * @param $form
+ * @param $errors
+ */
+function stripe_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
+  if ((isset($form->_paymentProcessor['payment`_processor_type']) &&$form->_paymentProcessor['payment_processor_type'] == 'Stripe') ||
+      isset($form->_elementIndex['stripe_token'])
+  ) {
+    if($form->elementExists('credit_card_number')){
+      $form->removeElement('credit_card_number');
+    }
+    if($form->elementExists('cvv2')){
+      $form->removeElement('cvv2');
+    }
+  }
+}
+
+/**
  * Add publishable key and event bindings for Stripe.js.
  */
 function stripe_add_stripe_js($form) {


### PR DESCRIPTION
This has been the greatest concern of ours with this extension. We've attempted to deal with this in the past through various means but nothing's really been that smooth. This feels undeniably hacky still but I like the fact that _it works_...

Basically, the frontend JS strips the `[name]` attribute from the CC and CVV2 fields which ensures the browser doesn't include the fields in the payload sent to the server. The issue with this is that Civi attempts to validate the fields and subsequently rejects the transaction when it doesn't see them.

Thus, a `validateForm` to the rescue! Now I worked on trying to modify validation rules but didn't seem to be able to get anywhere. What I found is that by removing the fields from the `$form` object during validation prevented any additional errors.

I've been thoroughly testing this with 4.5.5 on WP4.1 and it's been working great. I just don't know how hacky the `removeElement` approach is...
