### PR TITLE
Lookup contact's email address from API if missing from POST body

### DIFF
--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -245,6 +245,13 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     elseif (!empty($params['email-Primary'])) {
       $email = $params['email-Primary'];
     }
+    elseif (!empty($params['contact_id'])){
+      $email = civicrm_api3('Contact', 'getvalue', array(
+        'id' => $params['contact_id'],
+        'return' => 'email',
+      ));
+    }
+
     // Prepare escaped query params.
     $query_params = array(
       1 => array($email, 'String'),


### PR DESCRIPTION
This resolved my issue in #65 and seems like a good fallback for times when the contact's email simply isn't readily available due to inconsistencies in Civi payment forms. 

@drastik is it frowned upon to use `civicrm_api3` in this sort of situation? Should the lookup be done with something lower level?
