### PR TITLE
Add fields back to form after clearing associated rules

### DIFF
--- a/stripe.php
+++ b/stripe.php
@@ -123,12 +123,16 @@ function stripe_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  * @param $errors - Reference to the errors array.
  */
 function stripe_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
-  if (isset($form->_paymentProcessor['payment_processor_type']) &&$form->_paymentProcessor['payment_processor_type'] == 'Stripe') { 
+  if (isset($form->_paymentProcessor['payment_processor_type']) && $form->_paymentProcessor['payment_processor_type'] == 'Stripe') {
     if($form->elementExists('credit_card_number')){
-      $form->removeElement('credit_card_number');
+      $cc_field = $form->getElement('credit_card_number');
+      $form->removeElement('credit_card_number', true);
+      $form->addElement($cc_field);
     }
     if($form->elementExists('cvv2')){
-      $form->removeElement('cvv2');
+      $cvv2_field = $form->getElement('cvv2');
+      $form->removeElement('cvv2', true);
+      $form->addElement($cvv2_field);
     }
   }
 }


### PR DESCRIPTION
This PR seeks to solve the issue where the credit card fields are not displayed in the form when the user is returned following any error.

Instead of just removing the elements, instead...
1. Store element
2. Remove element (with `true` passed for second argument, removing rules)
3. Add element to form, sans rules
