### PR TITLE
Revert removal of class assignment in buildForm, use methods to apply

### DIFF
--- a/stripe.php
+++ b/stripe.php
@@ -143,14 +143,8 @@ function stripe_civicrm_buildForm($formName, &$form) {
   if (isset($form->_paymentProcessor['payment_processor_type']) && $form->_paymentProcessor['payment_processor_type'] == 'Stripe') {
     if (!stristr($formName, '_Confirm') && !stristr($formName, '_ThankYou')) {
       // This is the 'Main', or first step of the form that collects CC data.
-      if (!isset($form->_elementIndex['stripe_token'])) {
-/*
-*      Moved this to civicrm_stripe.js for webform patch
-*        if (empty($form->_attributes['class'])) {
-*          $form->_attributes['class'] = '';
-*        }
-*        $form->_attributes['class'] .= ' stripe-payment-form';
-*/
+      if (!$form->elementExists('stripe_token')) {
+        $form->setAttribute('class', $form->getAttribute('class') . ' stripe-payment-form');
         $form->addElement('hidden', 'stripe_token', NULL, array('id' => 'stripe-token'));
         $form->addElement('hidden', 'stripe_id', $form->_paymentProcessor['id'], array('id' => 'stripe-id'));
         stripe_add_stripe_js($form);


### PR DESCRIPTION
This accounts for the regression discussed [here](https://github.com/drastik/com.drastikbydesign.stripe/pull/75#commitcomment-9569035). It adds the potential for a duplication of effort as there is also logic in the JS to apply the class to the form however this ensures that the specificity in the JS `addClass` method won't exclude situations where the class should actually still be applied.

I've also spent some time learning PHP QuickForm  methods so I'll be applying some of those in the future too :smile: 
