### PR TITLE
Check q param for contact_id if not found anywhere else

### DIFF
--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -322,6 +322,18 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
       }
     }
 
+    // Last ditch effort-- check the URL for a contact ID?
+    if (empty($email)){
+      $parsed_query = array();
+      parse_str(html_entity_decode($parsed_url['query']), $parsed_query);
+      if(isset($parsed_query['cid'])){
+        $email = civicrm_api3('Contact', 'getvalue', array(
+          'id'     => $parsed_query['cid'],
+          'return' => 'email',
+        ));
+      }
+    }
+
     // We still didn't get an email address?!  /ragemode on
     if (empty($email)) {
       CRM_Core_Error::fatal(ts('No email address found.  Please report this issue.'));


### PR DESCRIPTION
Wouldn't ya know it? I found another annoying missing email use case. This time, the issue occurs while creating a credit card event registration directly from a contact's summary page. As crazy as it is, I was still reaching the damned 'No email address found' error!

This time, nowhere in the `$params` array was there even a mention of the contact id!

The only way I can figure that Civi is even able to process this information is by referencing the `q` param in the url.. I mean, it's got to be somewhere, right?

Anyway, if you'd rather see this integrated into the previous API check, I can do so, we'd just need to assert whether or not there exists any contact ID in `$params`
