### PR TITLE
validateForm update

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -49,7 +49,9 @@
       $('form.webform-client-form').addClass('stripe-payment-form');
     }
     else {
-      $('#crm-container>form').addClass('stripe-payment-form');
+      if (!($('.stripe-payment-form').length)) {
+        $('#crm-container>form').addClass('stripe-payment-form');
+      }
     }
     $form   = $('form.stripe-payment-form');
     if (isWebform) {

--- a/stripe.php
+++ b/stripe.php
@@ -123,7 +123,8 @@ function stripe_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  * @param $errors - Reference to the errors array.
  */
 function stripe_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
-  if (isset($form->_paymentProcessor['payment_processor_type']) && $form->_paymentProcessor['payment_processor_type'] == 'Stripe') {
+  if ((isset($form->_paymentProcessor['payment_processor_type']) &&$form->_paymentProcessor['payment_processor_type'] == 'Stripe')
+    || (!isset($form->_paymentProcessor['payment_processor_type']) && isset($form->_elementIndex['stripe_token']))) {
     if($form->elementExists('credit_card_number')){
       $cc_field = $form->getElement('credit_card_number');
       $form->removeElement('credit_card_number', true);


### PR DESCRIPTION
Fix problem with back-end forms not validating properly.  Not very elegant but it works.  I think there are going to be some additional changes to the validateForm hook anyway.

Also a minor change to civicrm_stripe.js so the script will only try to add the "stripe-payment-form" class if it is needed.
