### PR TITLE
issue #76: handle pay later in civi 4.6

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -146,14 +146,15 @@
 
       // Handle multiple payment options and Stripe not being chosen.
       if ($form.find(".crm-section.payment_processor-section").length > 0) {
-        if (!($form.find('input[name="hidden_processor"]').length > 0)) {
-          return true;
-        }
         if ($form.find('input[name="payment_processor"]:checked').length) {
           processorId=$form.find('input[name="payment_processor"]:checked').val();
           if (!($form.find('input[name="stripe_token"]').length) || ($('#stripe-id').length && $('#stripe-id').val() != processorId)) {
             return true;
           }
+        }
+        else {
+          // No payment processor is checked.
+          return true;
         }
       }
 


### PR DESCRIPTION
Due to changes in CiviCRM you can no longer count on hidden_processor
field being present.

See https://issues.civicrm.org/jira/browse/CRM-15743
