### PR TITLE
currentTotal is not defined on event registration pages.

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -143,9 +143,11 @@
       if ($('#priceset').length) {
         additionalParticipants = cj("#additional_participants").val();
         // The currentTotal is already being calculated in Form/Contribution/Main.tpl.
-        if (currentTotal == 0 && !additionalParticipants) {
-          // This is also hit when "Going back", but we already have stripe_token.
-          return true;
+        if(typeof currentTotal !== 'undefined') {
+          if (currentTotal == 0 && !additionalParticipants) {
+            // This is also hit when "Going back", but we already have stripe_token.
+            return true;
+          }
         }
       }
 


### PR DESCRIPTION
Addresses https://github.com/drastik/com.drastikbydesign.stripe/issues/109

This is not a fix - it's a work around.
