### PR TITLE
Fix cancelling of an existing subscription

### DIFF
--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -575,8 +575,8 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     // subscription per customer, we have to cancel the existing active
     // subscription first.
     $subscriptions = $stripe_customer->offsetGet('subscriptions');
-	  $data = $subscriptions->offsetGet('data');
-	  $status = $data[0]->offsetGet('status');
+    $data = $subscriptions->offsetGet('data');
+    $status = $data[0]->offsetGet('status');
     
     if (!empty($subscriptions) && $status == 'active') {
       $stripe_customer->cancelSubscription();

--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -574,7 +574,11 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     // card to be charged immediately.  So, since Stripe only supports one
     // subscription per customer, we have to cancel the existing active
     // subscription first.
-    if (!empty($stripe_customer->subscription) && $stripe_customer->subscription->status == 'active') {
+    $subscriptions = $stripe_customer->offsetGet('subscriptions');
+	  $data = $subscriptions->offsetGet('data');
+	  $status = $data[0]->offsetGet('status');
+    
+    if (!empty($subscriptions) && $status == 'active') {
       $stripe_customer->cancelSubscription();
     }
 


### PR DESCRIPTION
Before, the if statement never evaluated to true and so an existing subscription never got cancelled. This patch fixes the if statement to correctly check where there is an existing active subscription.
