### PR TITLE
Check if there are no existing subscriptions before attempting cancelling

### DIFF
--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -576,10 +576,13 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     // subscription first.
     $subscriptions = $stripe_customer->offsetGet('subscriptions');
     $data = $subscriptions->offsetGet('data');
-    $status = $data[0]->offsetGet('status');
     
-    if (!empty($subscriptions) && $status == 'active') {
-      $stripe_customer->cancelSubscription();
+    if(!empty($data)) {
+      $status = $data[0]->offsetGet('status');
+
+      if ($status == 'active') {
+        $stripe_customer->cancelSubscription();
+      }
     }
 
     // Attach the Subscription to the Stripe Customer.


### PR DESCRIPTION
Sorry, in my last pull request I was not checking whether the customer has no existing subscriptions. So `$data[0]->offsetGet('status')` was triggering a fatal error because $data is empty when there are no subscriptions. 
