### PR TITLE
Multiple Stripe processor accounts cause IPN fail

### DIFF
--- a/CRM/Stripe/Page/Webhook.php
+++ b/CRM/Stripe/Page/Webhook.php
@@ -59,7 +59,6 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
         }
         catch(Exception $e) {
           CRM_Core_Error::Fatal("Failed to retrieve Stripe charge.  Message: " . $e->getMessage());
-          exit();
         }
 
         // Find the recurring contribution in CiviCRM by mapping it from Stripe.
@@ -79,7 +78,6 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
             $end_time = $rel_info_query->end_time;
           } else {
             CRM_Core_Error::Fatal("Error relating this customer ($customer_id) to the one in civicrm_stripe_subscriptions");
-            exit();
           }
         }
 
@@ -95,7 +93,6 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
 
         if(!$recurring_contribution['id']) {
           CRM_Core_Error::Fatal("ERROR: Stripe triggered a Webhook on an invoice not found in civicrm_contribution_recur: " . $stripe_event_data);
-          exit();
         }
 
         // Build some params.
@@ -129,7 +126,7 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
               'fee_amount' => $fee
           ));
 
-          return;
+          CRM_Utils_System::civiExit();
         }
 
         //Get the original contribution with this invoice_id
@@ -168,7 +165,7 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
               SET end_date = %1, contribution_status_id = '1'
               WHERE invoice_id = %2", $query_params);
 
-            return;
+            CRM_Utils_System::civiExit();
           }
 
           // Successful charge & more to come
@@ -182,7 +179,7 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
                 'contribution_status_id' => "In Progress"
             ));
 
-            return;
+            CRM_Utils_System::civiExit();
           }
 
         break;
@@ -195,7 +192,6 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
         }
         catch(Exception $e) {
           CRM_Core_Error::Fatal("Failed to retrieve Stripe charge.  Message: " . $e->getMessage());
-          exit();
         }
 
         // Find the recurring contribution in CiviCRM by mapping it from Stripe.
@@ -207,7 +203,6 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
           WHERE customer_id = %1", $query_params);
         if (empty($invoice_id)) {
           CRM_Core_Error::Fatal("Error relating this customer ({$customer_id}) to the one in civicrm_stripe_subscriptions");
-          exit();
         }
 
         // Fetch Civi's info about this recurring object.
@@ -222,7 +217,6 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
         }
         else {
           CRM_Core_Error::Fatal("ERROR: Stripe triggered a Webhook on an invoice not found in civicrm_contribution_recur: " . $stripe_event_data);
-          exit();
         }
         // Build some params.
         $recieve_date = date("Y-m-d H:i:s", $charge->created);
@@ -269,7 +263,7 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
               SET contribution_status_id = 4
               WHERE invoice_id = %1", $query_params);
 
-            return;
+            CRM_Utils_System::civiExit();
           }
           else {
             // This has failed more than once.  Now what?
@@ -296,7 +290,6 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
             $invoice_id = $rel_info_query->invoice_id;
           } else {
             CRM_Core_Error::Fatal("Error relating this customer ($customer_id) to the one in civicrm_stripe_subscriptions");
-            exit();
           }
         }
 
@@ -310,7 +303,6 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
         if (!$recur_contribution['id']) {
           CRM_Core_Error::Fatal("ERROR: Stripe triggered a Webhook on an invoice not found in civicrm_contribution_recur: "
               . $stripe_event_data);
-          exit();
         }
 
         //Cancel the recurring contribution
@@ -331,7 +323,7 @@ class CRM_Stripe_Page_Webhook extends CRM_Core_Page {
       // One-time donation and per invoice payment.
       case 'charge.succeeded':
         // Not implemented.
-        return;
+        CRM_Utils_System::civiExit();
         break;
 
     }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ For Drupal:  https://example.com/civicrm/stripe/webhook
 For Joomla:  https://example.com/index.php/component/civicrm/?task=civicrm/stripe/webhook  
 For Wordpress:  https://example.com/?page=CiviCRM&q=civicrm/stripe/webhook  
 
+If you have multiple Stripe accounts on your site, you will need to specify the payment processor ID in the webhook URL.
+To find the ID, look at the URL when you are editing the payment processor in CiviCRM: it should include `id=XX`, where `XX` is your payment processor ID.
+Add a URL parameter of `ppid=XX` to the webhook URL.
+For example, for a payment processor ID of 3, use the following:
+For Drupal:  https://example.com/civicrm/stripe/webhook?ppid=3
+For Joomla:  https://example.com/index.php/component/civicrm/?task=civicrm/stripe/webhook&ppid=3
+For Wordpress:  https://example.com/?page=CiviCRM&q=civicrm/stripe/webhook&ppid=3
+
 INSTALLATION
 ------------
 For CiviCRM 4.4 & up:  


### PR DESCRIPTION
When there are multiple Stripe payment processors on a site, the webhook just gets the API key from the first one.  That means that the "event" lookup fails for the other Stripe instances.

I added an optional `ppid` URL parameter that lets you specify the payment processor ID.

I know this is not the new preferred URL format per @eileenmcnaughton's [comment on CRM-18107](https://issues.civicrm.org/jira/browse/CRM-18107?focusedCommentId=86710&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-86710), but I wanted to introduce a modest change that leaves the URL alone for the 99% of instances where there's only one Stripe account and/or no recurring donations.

Separately, I got annoyed dealing with all the other page markup when testing the webhook calls, so I made sure that the page run exits rather than returning.  `CRM_Core_Error::fatal()` exits anyway, so I got rid of the superfluous `exit()` calls following it.
