### PR TITLE
If there's no credit card field, don't attempt to get token

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -177,6 +177,12 @@
         return true;
       }
 
+      // If there's no credit card field, no use in continuing (probably wrong
+      // context anyway)
+      if (!$form.find('#credit_card_number').length) {
+        return true;
+      }
+
       event.preventDefault();
       event.stopPropagation();
 


### PR DESCRIPTION
If a CiviDiscount code gives you 100% off for an event, the main registration form knows not to try to get the token.  However, on the confirmation form, there's no token, and civicrm_stripe.js is loaded, so it tries to get the token when you submit the confirmation form.  This yields a `Missing required param: number` error because there's no credit card number field to get the number from.

I bet there could be a more specific fix to prevent civicrm_stripe.js from loading on a confirmation page with no fee, but regardless, there's never a point when you'd want to try getting a token and there's no credit card number field.
