### PR TITLE
Errors when donors repeat across multiple stripe accounts

### DIFF
--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -600,11 +600,12 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     // Prepare escaped query params.
     $query_params = array(
       1 => array($stripe_customer->id, 'String'),
+      2 => array($this->_paymentProcessor['id'], 'Integer'),
     );
 
     $existing_subscription_query = CRM_Core_DAO::singleValueQuery("SELECT invoice_id
       FROM civicrm_stripe_subscriptions
-      WHERE customer_id = %1 AND is_live = '{$this->_islive}'", $query_params);
+      WHERE customer_id = %1 AND is_live = '{$this->_islive}', and processor_id = %2", $query_params);
 
     if (!empty($existing_subscription_query)) {
       // Cancel existing Recurring Contribution in CiviCRM.
@@ -613,6 +614,7 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
       // Prepare escaped query params.
       $query_params = array(
         1 => array($existing_subscription_query, 'String'),
+        2 => array($this->_paymentProcessor['id'], 'Integer'),
       );
 
       CRM_Core_DAO::executeQuery("UPDATE civicrm_contribution_recur
@@ -632,21 +634,22 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     $query_params = array(
       1 => array($stripe_customer->id, 'String'),
       2 => array($invoice_id, 'String'),
+      2 => array($this->_paymentProcessor['id'], 'Integer'),
     );
 
     // Insert the new Stripe Subscription info.
     // Set end_time to NULL if installments are ongoing indefinitely
     if (empty($installments)) {
       CRM_Core_DAO::executeQuery("INSERT INTO civicrm_stripe_subscriptions
-        (customer_id, invoice_id, is_live)
-        VALUES (%1, %2, '{$this->_islive}')", $query_params);
+        (customer_id, invoice_id, is_live, processor_id)
+        VALUES (%1, %2, '{$this->_islive}', %3)", $query_params);
     }
     else {
       // Add the end time to the query params.
       $query_params[3] = array($end_time, 'Integer');
       CRM_Core_DAO::executeQuery("INSERT INTO civicrm_stripe_subscriptions
-        (customer_id, invoice_id, end_time, is_live)
-        VALUES (%1, %2, %3, '{$this->_islive}')", $query_params);
+        (customer_id, invoice_id, end_time, is_live, processor_id)
+        VALUES (%1, %2, %3, '{$this->_islive}', %3)", $query_params);
     }
 
     return $params;

--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -535,11 +535,12 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     // Prepare escaped query params.
     $query_params = array(
       1 => array($plan_id, 'String'),
+      2 => array($this->_paymentProcessor['id'], 'Integer'),
     );
 
     $stripe_plan_query = CRM_Core_DAO::singleValueQuery("SELECT plan_id
       FROM civicrm_stripe_plans
-      WHERE plan_id = %1 AND is_live = '{$this->_islive}'", $query_params);
+      WHERE plan_id = %1 AND is_live = '{$this->_islive}' AND processor_id = %2", $query_params);
 
     if (!isset($stripe_plan_query)) {
       $formatted_amount = '$' . number_format(($amount / 100), 2);
@@ -564,9 +565,10 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
       // Prepare escaped query params.
       $query_params = array(
         1 => array($plan_id, 'String'),
+        2 => array($this->_paymentProcessor['id'], 'Integer'),
       );
-      CRM_Core_DAO::executeQuery("INSERT INTO civicrm_stripe_plans (plan_id, is_live)
-        VALUES (%1, '{$this->_islive}')", $query_params);
+      CRM_Core_DAO::executeQuery("INSERT INTO civicrm_stripe_plans (plan_id, is_live, processor_id)
+        VALUES (%1, '{$this->_islive}', %2)", $query_params);
     }
 
     // If a contact/customer has an existing active recurring

--- a/CRM/Stripe/Upgrader.php
+++ b/CRM/Stripe/Upgrader.php
@@ -67,6 +67,7 @@ class CRM_Stripe_Upgrader extends CRM_Stripe_Upgrader_Base {
       $this->ctx->log->info('Applying civicrm_stripe update 4601.  Adding processor_id to civicrm_stripe_customers and civicrm_stripe_plans table.');
       CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_stripe_customers ADD COLUMN `processor_id` int(10) DEFAULT NULL COMMENT "ID from civicrm_payment_processor"');
       CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_stripe_plans ADD COLUMN `processor_id` int(10) DEFAULT NULL COMMENT "ID from civicrm_payment_processor"');
+      CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_stripe_subscriptions ADD COLUMN `processor_id` int(10) DEFAULT NULL COMMENT "ID from civicrm_payment_processor"');
     }
     return TRUE;
   }

--- a/CRM/Stripe/Upgrader.php
+++ b/CRM/Stripe/Upgrader.php
@@ -61,11 +61,12 @@ class CRM_Stripe_Upgrader extends CRM_Stripe_Upgrader_Base {
   public function upgrade_4_6_01() {
     $procIdCheck = mysql_query("SHOW COLUMNS FROM `civicrm_stripe_customers` LIKE 'processor_id'");
     if (mysql_num_rows($procIdCheck)) {
-      $this->ctx->log->info('Skipped civicrm_stripe update 4601.  Column processor_id already present on civicrm_stripe_customers table.');
+      $this->ctx->log->info('Skipped civicrm_stripe update 4601.  Column processor_id already present on civicrm_stripe_customers and civicrm_stripe_plans table.');
     }
     else {
-      $this->ctx->log->info('Applying civicrm_stripe update 4601.  Adding processor_id to civicrm_stripe_customers table.');
+      $this->ctx->log->info('Applying civicrm_stripe update 4601.  Adding processor_id to civicrm_stripe_customers and civicrm_stripe_plans table.');
       CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_stripe_customers ADD COLUMN `processor_id` int(10) DEFAULT NULL COMMENT "ID from civicrm_payment_processor"');
+      CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_stripe_plans ADD COLUMN `processor_id` int(10) DEFAULT NULL COMMENT "ID from civicrm_payment_processor"');
     }
     return TRUE;
   }

--- a/CRM/Stripe/Upgrader.php
+++ b/CRM/Stripe/Upgrader.php
@@ -51,4 +51,23 @@ class CRM_Stripe_Upgrader extends CRM_Stripe_Upgrader_Base {
     }
     return TRUE;
   }
+
+  /**
+   * Add processor_id column to civicrm_stripe_customers table.
+   *
+   * @return TRUE on success
+   * @throws Exception
+   */
+  public function upgrade_4_6_01() {
+    $procIdCheck = mysql_query("SHOW COLUMNS FROM `civicrm_stripe_customers` LIKE 'processor_id'");
+    if (mysql_num_rows($procIdCheck)) {
+      $this->ctx->log->info('Skipped civicrm_stripe update 4601.  Column processor_id already present on civicrm_stripe_customers table.');
+    }
+    else {
+      $this->ctx->log->info('Applying civicrm_stripe update 4601.  Adding processor_id to civicrm_stripe_customers table.');
+      CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_stripe_customers ADD COLUMN `processor_id` int(10) DEFAULT NULL COMMENT "ID from civicrm_payment_processor"');
+    }
+    return TRUE;
+  }
+
 }

--- a/stripe.php
+++ b/stripe.php
@@ -32,6 +32,7 @@ function stripe_civicrm_install() {
     `email` varchar(64) COLLATE utf8_unicode_ci DEFAULT NULL,
     `id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
     `is_live` tinyint(4) NOT NULL COMMENT 'Whether this is a live or test transaction',
+    `processor_id` int(10) DEFAULT NULL COMMENT 'ID from civicrm_payment_processor',
     UNIQUE KEY `id` (`id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
   ");

--- a/stripe.php
+++ b/stripe.php
@@ -41,6 +41,7 @@ function stripe_civicrm_install() {
   CREATE TABLE IF NOT EXISTS `civicrm_stripe_plans` (
     `plan_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
     `is_live` tinyint(4) NOT NULL COMMENT 'Whether this is a live or test transaction',
+    `processor_id` int(10) DEFAULT NULL COMMENT 'ID from civicrm_payment_processor',
     UNIQUE KEY `plan_id` (`plan_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
   ");

--- a/stripe.php
+++ b/stripe.php
@@ -52,6 +52,7 @@ function stripe_civicrm_install() {
     `invoice_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
     `end_time` int(11) NOT NULL DEFAULT '0',
     `is_live` tinyint(4) NOT NULL COMMENT 'Whether this is a live or test transaction',
+    `processor_id` int(10) DEFAULT NULL COMMENT 'ID from civicrm_payment_processor',
     KEY `end_time` (`end_time`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
   ");


### PR DESCRIPTION
If a site has two stripe accounts and someone donates via one and then via the other, the second contribution will fail because the customer ID won't be found in the other account.  This bypasses that by checking the payment processor ID.

NOTE: This is tested in 4.6 on one-off donations.  I have not tested this on subscriptions or plans because our client with multiple accounts does not have those.  I have no reason to think that it won't work there, but I can't vouch for it.
