### PR TITLE
Don't submit if the back button is clicked

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -62,7 +62,11 @@
 
       // If CiviDiscount button or field is submitted, flag the form.
       $form.data('cividiscount-dont-handle', '0');
-      $form.find('input[type="submit"][formnovalidate="1"]').click( function() {
+      // This is an ugly hack. Really, the code should positively identify the
+      // "real" submit button(s) and only respond to them.  Otherwise, we're
+      // chasing down a potentially endless number of exceptions.  The problem
+      // is that it's unclear if CiviCRM consistently names its submit buttons.
+      $form.find('input[type="submit"][formnovalidate="1"], input[type="submit"].cancel').click( function() {
         $form.data('cividiscount-dont-handle', 1);
       });
       $form.find('input#discountcode').keypress( function(e) {


### PR DESCRIPTION
This addresses #144 by ignoring submit buttons with the class `cancel`, which is given to the "Go back" buttons on event and contribution confirmation pages.

I added a comment to highlight that this is still undesirable: we're chasing down all of the buttons that should be _ignored_ because the extension assumes that any submit button submits.  I'd rather see us positively identifying the button(s) that _do_ matter and listening only for them
