### PR TITLE
Give precedence to server added class.

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -44,15 +44,18 @@
       Stripe.setPublishableKey($('#stripe-pub-key').val());
     });
 
-    if ($('.webform-client-form').length) {
-      isWebform = true;
-      $('form.webform-client-form').addClass('stripe-payment-form');
-    }
-    else {
-      if (!($('.stripe-payment-form').length)) {
-        $('#crm-container > form').addClass('stripe-payment-form');
+    // Check for form marked as a stripe-payment-form by the server.
+    if (!($('form.stripe-payment-form').length)) {
+      // If there isn't one look for it.
+      if ($('.webform-client-form').length) {
+        isWebform = true;
+        $('form.webform-client-form').addClass('stripe-payment-form');
+      }
+      else {
+	      $('#crm-container > form').addClass('stripe-payment-form');
       }
     }
+
     $form   = $('form.stripe-payment-form');
     if (isWebform) {
       $submit = $form.find('.button-primary');


### PR DESCRIPTION
Look to see if the server already gave the `stripe-payment-form` class to a form before adding it to a form on the client side.

See #202 for an example of a problem you can run into with the current implementation.