### PR TITLE
Check for isBackOffice instead of individual forms

### DIFF
--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -277,12 +277,13 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     if (empty($form->_paymentProcessor)) {
       return;
     }
-    // Determine if we are dealing with a webform in CiviCRM 4.7.  Those don't have a
-    //  _paymentProcessors array and only have one payprocesssor.
 
-    // When called from admin backend (forms such as CRM_Financial_Form_Payment, CRM_Contribute_Form_Contribution, CRM_Member_Form_Membership)
+    // When called from admin backend (eg via CRM_Contribute_Form_Contribution, CRM_Member_Form_Membership)
     // the isBackOffice flag will be set to true.
-    if (!empty($form->isBackOffice)) {
+    // But if called via webform in CiviCRM 4.7: isBackOffice=NULL and for is of class CRM_Financial_Form_Payment or CRM_Contribute_Form_Contribution
+    // Those don't have a _paymentProcessors array and only have one payprocesssor.
+    if (!empty($form->isBackOffice)
+      || (in_array(get_class($form), array('CRM_Financial_Form_Payment', 'CRM_Contribute_Form_Contribution')))) {
       return $stripe_ppid = $form->_paymentProcessor['id'];
     }
     else {

--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -279,15 +279,15 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     }
     // Determine if we are dealing with a webform in CiviCRM 4.7.  Those don't have a
     //  _paymentProcessors array and only have one payprocesssor.
-   
+
     // When called from admin backend (forms such as CRM_Financial_Form_Payment, CRM_Contribute_Form_Contribution, CRM_Member_Form_Membership)
     // the isBackOffice flag will be set to true.
-    if (!empty($form->isBackOffice) || (in_array(get_class($form), array('CRM_Financial_Form_Payment')))) {
+    if (!empty($form->isBackOffice)) {
       return $stripe_ppid = $form->_paymentProcessor['id'];
     }
     else {
       // Find a Stripe pay processor ascociated with this Civi form and find the ID.
-   //   $payProcessors = $form->_paymentProcessors;
+      //   $payProcessors = $form->_paymentProcessors;
       $payProcessors = CRM_Core_Form_Stripe::get_ppids($form);
       foreach ($payProcessors as $payProcessor) {
         if ($payProcessor['class_name'] == 'Payment_Stripe') {

--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -279,7 +279,10 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
     }
     // Determine if we are dealing with a webform in CiviCRM 4.7.  Those don't have a
     //  _paymentProcessors array and only have one payprocesssor.
-    if (in_array(get_class($form), array('CRM_Financial_Form_Payment', 'CRM_Contribute_Form_Contribution'))) {
+   
+    // When called from admin backend (forms such as CRM_Financial_Form_Payment, CRM_Contribute_Form_Contribution, CRM_Member_Form_Membership)
+    // the isBackOffice flag will be set to true.
+    if (!empty($form->isBackOffice) || (in_array(get_class($form), array('CRM_Financial_Form_Payment')))) {
       return $stripe_ppid = $form->_paymentProcessor['id'];
     }
     else {


### PR DESCRIPTION
I found another form on the backend that crashes CiviCRM if not set. CRM_Member_Form_Membership.  However, I think checking the flag isBackOffice may be a better option than checking for each form class so this PR does that.  I have not verified if this still works with webforms etc.