### PR TITLE
deal with same release date on tags 4.7.2 and 4.7.1

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -11,8 +11,8 @@
     <author>Joshua Walker (drastik) - Drastik by Design</author>
     <email>admin@drastikbydesign.com</email>
   </maintainer>
-  <releaseDate>2016-11-06</releaseDate>
-  <version>4.7.2</version>
+  <releaseDate>2017-10-25</releaseDate>
+  <version>4.7.3</version>
   <compatibility>
     <ver>4.5</ver>
     <ver>4.6</ver>


### PR DESCRIPTION
I believe to fix the release date on 4.7.2 best practices say one should create a new 4.7.3 tag with corrected date. It gets a bit messy at this point trying to put a release date of 2017-09-07 in with that tag.